### PR TITLE
Ignore additional MAPI challenge fields instead of raising an error

### DIFF
--- a/src/ServerChallenge.php
+++ b/src/ServerChallenge.php
@@ -77,9 +77,9 @@ class ServerChallenge {
     {
         $parts = explode(':', $challengeLine);
         $count = count($parts) - 1;     	// Last is always empty
-        if ($count != 6) {
+        if ($count < 6) {
             throw new MonetException("Received invalid 'server challenge' string from the server. It"
-                ." contains {$count} fields, instead of 6.");
+                ." contains {$count} fields, should be at least 6.");
         }
 
         $this->salt = trim($parts[0]);


### PR DESCRIPTION
As long as the version number remains 9, unknown challenge fields can
safely be ignored.

The next release of MonetDB will send one such an additional field.